### PR TITLE
Added: 增加IPv6支持

### DIFF
--- a/src/sf_connection_manager.c
+++ b/src/sf_connection_manager.c
@@ -521,7 +521,7 @@ int sf_connection_manager_init_ex(SFConnectionManager *cm,
         connect_done_callback, void *args, FCServerConfig *server_cfg,
         const bool bg_thread_enabled)
 {
-    const int socket_domain = AF_INET;
+    const int socket_domain = AF_UNSPEC;
     int htable_init_capacity;
     int result;
 

--- a/src/sf_service.c
+++ b/src/sf_service.c
@@ -25,6 +25,7 @@
 #include <string.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <ifaddrs.h>
 #include "fastcommon/logger.h"
 #include "fastcommon/sockopt.h"
 #include "fastcommon/shared_func.h"
@@ -348,7 +349,23 @@ static void *worker_thread_entrance(void *arg)
 static int _socket_server(const char *bind_addr, int port, int *sock)
 {
     int result;
-    *sock = socketServer(bind_addr, port, &result);
+
+    // 如果bind_addr未设置
+    if(strlen(bind_addr) == 0){
+
+        // 如果当前服务不存在IPv4地址，但是存在IPv6地址，则自动绑定IPv6地址
+        if(!checkHostHasIPv4Addr() && checkHostHasIPv6Addr()){
+            *sock = socketServerIPv6(bind_addr, port, &result);
+        }else{
+            *sock = socketServer(bind_addr, port, &result);
+        }
+    }else if (is_ipv6_addr(bind_addr))     // 通过判断IP地址是IPv4或者IPv6，根据结果进行初始化
+    {
+        *sock = socketServerIPv6(bind_addr, port, &result);
+    }else{
+        *sock = socketServer(bind_addr, port, &result);
+    }
+
     if (*sock < 0) {
         return result;
     }
@@ -759,4 +776,56 @@ void sf_notify_all_threads_ex(SFContext *sf_context)
 void sf_set_sig_quit_handler(sf_sig_quit_handler quit_handler)
 {
     sig_quit_handler = quit_handler;
+}
+
+// 判断当前服务器是否存在IPv4地址
+bool checkHostHasIPv4Addr(){
+    struct ifaddrs *ifaddr, *ifa;
+    if (getifaddrs(&ifaddr) == -1) {
+        return false;
+    }
+
+    bool hasIPv4 = false;
+    for (ifa = ifaddr; ifa != NULL; ifa = ifa->ifa_next) {
+        if (ifa->ifa_addr == NULL) {
+            continue;
+        }
+        if (strcmp(ifa->ifa_name, "lo") == 0) { // 排除lo接口
+            continue;
+        }
+        if (ifa->ifa_addr->sa_family == AF_INET) {
+            hasIPv4 = true;
+            break;
+        }
+    }
+
+    freeifaddrs(ifaddr);
+
+    return hasIPv4;
+}
+
+// 判断当前服务器是否存在IPv6地址
+bool checkHostHasIPv6Addr(){
+    struct ifaddrs *ifaddr, *ifa;
+    if (getifaddrs(&ifaddr) == -1) {
+        return false;
+    }
+
+    bool hasIPv6 = false;
+    for (ifa = ifaddr; ifa != NULL; ifa = ifa->ifa_next) {
+        if (ifa->ifa_addr == NULL) {
+            continue;
+        }
+        if (strcmp(ifa->ifa_name, "lo") == 0) { // 排除lo接口
+            continue;
+        }
+        if (ifa->ifa_addr->sa_family == AF_INET6) {
+             hasIPv6 = true;
+            break;
+        }
+    }
+
+    freeifaddrs(ifaddr);
+
+    return hasIPv6;
 }

--- a/src/sf_service.h
+++ b/src/sf_service.h
@@ -161,6 +161,12 @@ static inline void sf_release_task(struct fast_task_info *task)
     }
 }
 
+// 判断当前服务器是否存在IPv4地址
+bool checkHostHasIPv4Addr();
+
+// 判断当前服务器是否存在IPv6地址
+bool checkHostHasIPv6Addr();
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/sf_types.h
+++ b/src/sf_types.h
@@ -35,7 +35,7 @@
 #define SF_SERVER_TASK_TYPE_CHANNEL_USER       102   //for request idempotency
 
 typedef int (*sf_accept_done_callback)(struct fast_task_info *task,
-        const in_addr_t client_addr, const bool bInnerPort);
+        const in_addr_64_t client_addr, const bool bInnerPort);
 typedef int (*sf_set_body_length_callback)(struct fast_task_info *task);
 typedef char *(*sf_alloc_recv_buffer_callback)(struct fast_task_info *task,
         const int buff_size, bool *new_alloc);


### PR DESCRIPTION
1、增加检测主机是否配置IPv4地址和是否配置IPv6地址的方法。
2、修改sf_service.c文件中_socket_server方法，以支持IPv4和IPv6地址，当服务器为双栈时，优先选择IPv4地址。